### PR TITLE
Clarify review app security guidance

### DIFF
--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -40,6 +40,16 @@ For review apps, GitHub needs these repository secrets:
 | `CPLN_TOKEN_STAGING` | Control Plane service-account token for the staging org. |
 | `SHARED_POSTGRES_URL_PREFIX` | Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
 
+Use a staging/review token that cannot access production Control Plane
+resources. In public repositories, review-app deploys skip fork PR heads
+because Docker builds and database setup use repository secrets. If a forked
+change needs a review app, first move the reviewed change to a trusted branch
+in this repository.
+
+Review apps run pull request code. Keep `SHARED_POSTGRES_URL_PREFIX` pointed at
+a review-safe database server with no production or customer data, and use
+database credentials that are acceptable for temporary review databases.
+
 No GitHub repository variables are required for the normal review-app workflow.
 The local workflow defaults to `react-on-rails-hn-rsc-demo-review-pr` in
 `shakacode-open-source-examples-staging`.
@@ -108,6 +118,12 @@ openssl rand -hex 32 # RENDERER_PASSWORD
 The deploy workflow creates the database secret dictionary `<app-name>-database`
 from `SHARED_POSTGRES_URL_PREFIX`. Do not add `.controlplane/templates/postgres.yml`
 or a `postgres` workload for review/staging apps.
+
+Values mounted through `cpln://secret/...` can be read by application code after
+the review app starts. Keep review-app secrets disposable or review-only:
+separate renderer credentials, generated `SECRET_KEY_BASE` values, and a Pro
+license value that is acceptable for review-app exposure. Do not reuse
+production or long-lived staging secret dictionaries for review apps.
 
 ## Local Validation
 

--- a/.controlplane/templates/app.yml
+++ b/.controlplane/templates/app.yml
@@ -21,6 +21,9 @@ spec:
       value: "true"
     - name: RAILS_SERVE_STATIC_FILES
       value: "true"
+    # Review apps run pull request code. Values mounted through cpln://secret
+    # become readable by that code after the workload starts, so app and
+    # database secret dictionaries must contain review-safe values.
     - name: SECRET_KEY_BASE
       value: "cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE"
     - name: REACT_RENDERER_URL

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -25,6 +25,17 @@ For this shared-Postgres review-app path, GitHub needs two repository secrets:
 | `CPLN_TOKEN_STAGING` | Repository secret | Control Plane service-account token for the staging/review org. |
 | `SHARED_POSTGRES_URL_PREFIX` | Repository secret | Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
 
+Use a staging/review token that cannot access production Control Plane
+resources. Review-app deploys skip fork PR heads because Docker builds and
+database setup use repository secrets. If a forked change needs a review app,
+first move the reviewed change to a trusted branch in this repository.
+
+Review apps run pull request code. Keep `SHARED_POSTGRES_URL_PREFIX` pointed at
+a review-safe database server with no production or customer data, and keep
+mounted app secrets limited to review-only renderer credentials, generated
+`SECRET_KEY_BASE` values, and license values that are acceptable for review-app
+exposure.
+
 No repository variables are required for the standard review-app path. The local
 workflows default to review app prefix `react-on-rails-hn-rsc-demo-review-pr`,
 staging app `react-on-rails-hn-rsc-demo-staging`, staging org
@@ -129,7 +140,7 @@ Most apps do not need these:
 | Name | Notes |
 | --- | --- |
 | `DOCKER_BUILD_EXTRA_ARGS` | Newline-delimited extra Docker build tokens. |
-| `DOCKER_BUILD_SSH_KEY` | Private SSH key for Docker builds that fetch private dependencies. |
+| `DOCKER_BUILD_SSH_KEY` | Read-only, revocable deploy key for Docker builds that fetch private dependencies. Do not use a personal SSH key. |
 | `DOCKER_BUILD_SSH_KNOWN_HOSTS` | SSH known_hosts entries when SSH build hosts are not GitHub.com. |
 | `REVIEW_APP_DEPLOYING_ICON_URL` | Cosmetic custom image URL for the animated deploying icon. Set to `none` to use the text fallback icon. |
 | `STAGING_APP_BRANCH` | Custom staging branch. The branch must also appear in `cpflow-deploy-staging.yml`'s push filter. |


### PR DESCRIPTION
## Summary

- add review-app security guidance to the HN RSC demo cpflow setup
- document that fork PR heads are skipped and that shared Postgres/review-app secrets must be review-safe
- recommend production-isolated Control Plane tokens, review-safe database credentials, renderer credentials, and Pro license values

## Verification

- `git diff --check`

Note: PR #41 has merged, so this PR now targets `main` with the follow-up security guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and inline template comments only; no workflow or application runtime behavior changes.
> 
> **Overview**
> Adds **review-app security guidance** to the cpflow setup docs and template comments so operators treat PR deploys as untrusted code with access to mounted secrets.
> 
> The updates spell out that **`CPLN_TOKEN_STAGING` must not reach production**, that **fork PR heads are skipped** for review deploys (and how to get a review app from fork work), and that **`SHARED_POSTGRES_URL_PREFIX` and database credentials** must point at review-only data. They also warn that **`cpln://secret/...` values are readable by PR code**, so review apps need disposable **`SECRET_KEY_BASE`**, renderer credentials, and Pro license values—not production or long-lived staging dictionaries.
> 
> **`.github/cpflow-help.md`** additionally clarifies **`DOCKER_BUILD_SSH_KEY`** should be a read-only, revocable deploy key, not a personal SSH key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fef271d2035407273f5dd7f8f9ce44dd48cd650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->