### PR TITLE
Use Control Plane database secret as Postgres prefix source

### DIFF
--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -38,7 +38,7 @@ For review apps, GitHub needs these repository secrets:
 | Secret | Notes |
 | --- | --- |
 | `CPLN_TOKEN_STAGING` | Control Plane service-account token for the staging org. |
-| `SHARED_POSTGRES_URL_PREFIX` | Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
+| `SHARED_POSTGRES_URL_PREFIX` | Optional when `SHARED_POSTGRES_SOURCE_SECRET` points at an existing Control Plane database secret. Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
 
 Use a staging/review token that cannot access production Control Plane
 resources. In public repositories, review-app deploys skip fork PR heads
@@ -50,16 +50,19 @@ Review apps run pull request code. Keep `SHARED_POSTGRES_URL_PREFIX` pointed at
 a review-safe database server with no production or customer data, and use
 database credentials that are acceptable for temporary review databases.
 
-No GitHub repository variables are required for the normal review-app workflow.
-The local workflow defaults to `react-on-rails-hn-rsc-demo-review-pr` in
-`shakacode-open-source-examples-staging`.
+`SHARED_POSTGRES_SOURCE_SECRET` can be set as a repository variable when the
+prefix should be derived from an existing Control Plane dictionary secret with a
+`DATABASE_URL` entry. It defaults to
+`react-on-rails-hn-rsc-demo-staging-database`. The local workflow defaults to
+`react-on-rails-hn-rsc-demo-review-pr` in `shakacode-open-source-examples-staging`.
 
 For staging auto-deploys, configure:
 
 | Secret or variable | Value |
 | --- | --- |
 | `CPLN_TOKEN_STAGING` | Same staging Control Plane token used by review apps. |
-| `SHARED_POSTGRES_URL_PREFIX` | Same shared Postgres URL prefix used by review apps. |
+| `SHARED_POSTGRES_URL_PREFIX` | Optional when the staging database secret already exists in Control Plane. Same shared Postgres URL prefix used by review apps. |
+| `SHARED_POSTGRES_SOURCE_SECRET` | Optional existing Control Plane dictionary secret used to derive the shared Postgres URL prefix. Defaults to `react-on-rails-hn-rsc-demo-staging-database`. |
 | `CPLN_ORG_STAGING` | `shakacode-open-source-examples-staging` |
 | `STAGING_APP_NAME` | `react-on-rails-hn-rsc-demo-staging` |
 
@@ -116,8 +119,10 @@ openssl rand -hex 32 # RENDERER_PASSWORD
 ```
 
 The deploy workflow creates the database secret dictionary `<app-name>-database`
-from `SHARED_POSTGRES_URL_PREFIX`. Do not add `.controlplane/templates/postgres.yml`
-or a `postgres` workload for review/staging apps.
+from `SHARED_POSTGRES_URL_PREFIX`, or derives that prefix from
+`SHARED_POSTGRES_SOURCE_SECRET` when the GitHub secret is not set. Do not add
+`.controlplane/templates/postgres.yml` or a `postgres` workload for
+review/staging apps.
 
 Values mounted through `cpln://secret/...` can be read by application code after
 the review app starts. Keep review-app secrets disposable or review-only:

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -23,7 +23,8 @@ For this shared-Postgres review-app path, GitHub needs two repository secrets:
 | Name | Where | Notes |
 | --- | --- | --- |
 | `CPLN_TOKEN_STAGING` | Repository secret | Control Plane service-account token for the staging/review org. |
-| `SHARED_POSTGRES_URL_PREFIX` | Repository secret | Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
+| `SHARED_POSTGRES_URL_PREFIX` | Repository secret | Optional when `SHARED_POSTGRES_SOURCE_SECRET` points at an existing Control Plane database secret. Shared Postgres connection URL without a database name, for example `postgres://user:password@postgres.staging-shared-postgres.cpln.local:5432`. |
+| `SHARED_POSTGRES_SOURCE_SECRET` | Repository variable | Optional existing Control Plane dictionary secret with a `DATABASE_URL` entry. Defaults to `react-on-rails-hn-rsc-demo-staging-database`. |
 
 Use a staging/review token that cannot access production Control Plane
 resources. Review-app deploys skip fork PR heads because Docker builds and
@@ -36,10 +37,12 @@ mounted app secrets limited to review-only renderer credentials, generated
 `SECRET_KEY_BASE` values, and license values that are acceptable for review-app
 exposure.
 
-No repository variables are required for the standard review-app path. The local
-workflows default to review app prefix `react-on-rails-hn-rsc-demo-review-pr`,
-staging app `react-on-rails-hn-rsc-demo-staging`, staging org
-`shakacode-open-source-examples-staging`, and primary workload `rails`.
+No repository variables are required for the standard review-app path when the
+default staging database secret exists. The local workflows default to review
+app prefix `react-on-rails-hn-rsc-demo-review-pr`, staging app
+`react-on-rails-hn-rsc-demo-staging`, staging org
+`shakacode-open-source-examples-staging`, source database secret
+`react-on-rails-hn-rsc-demo-staging-database`, and primary workload `rails`.
 
 Optional overrides exist for forks, clones, and unusual apps:
 
@@ -47,13 +50,14 @@ Optional overrides exist for forks, clones, and unusual apps:
 | --- | --- |
 | `CPLN_ORG_STAGING` | Override the staging/review Control Plane org inferred from `controlplane.yml`. |
 | `REVIEW_APP_PREFIX` | Override the review-app prefix inferred from `controlplane.yml`. |
+| `SHARED_POSTGRES_SOURCE_SECRET` | Existing Control Plane database secret used to derive the shared Postgres URL prefix when `SHARED_POSTGRES_URL_PREFIX` is not set. |
 | `PRIMARY_WORKLOAD` | Public workload used for review URLs and health checks; defaults to `rails`. |
 
 ## Staging And Production
 
-Staging deploys use the same `CPLN_TOKEN_STAGING` and
-`SHARED_POSTGRES_URL_PREFIX` secrets. `STAGING_APP_NAME` defaults to
-`react-on-rails-hn-rsc-demo-staging`.
+Staging deploys use `CPLN_TOKEN_STAGING` plus either
+`SHARED_POSTGRES_URL_PREFIX` or `SHARED_POSTGRES_SOURCE_SECRET`.
+`STAGING_APP_NAME` defaults to `react-on-rails-hn-rsc-demo-staging`.
 Before the first staging deploy, bootstrap the persistent staging app once:
 
 ```sh

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -56,7 +56,6 @@ jobs:
 
           missing=()
           [[ -n "${{ secrets.CPLN_TOKEN_STAGING }}" ]] || missing+=("secret:CPLN_TOKEN_STAGING")
-          [[ -n "${{ secrets.SHARED_POSTGRES_URL_PREFIX }}" ]] || missing+=("secret:SHARED_POSTGRES_URL_PREFIX")
 
           if [[ ${#missing[@]} -gt 0 ]]; then
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -203,6 +202,7 @@ jobs:
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         env:
           SHARED_POSTGRES_URL_PREFIX: ${{ secrets.SHARED_POSTGRES_URL_PREFIX }}
+          SHARED_POSTGRES_SOURCE_SECRET: ${{ vars.SHARED_POSTGRES_SOURCE_SECRET || 'react-on-rails-hn-rsc-demo-staging-database' }}
         shell: bash
         run: script/control-plane/ensure-shared-postgres-secret
 

--- a/.github/workflows/cpflow-deploy-staging.yml
+++ b/.github/workflows/cpflow-deploy-staging.yml
@@ -31,7 +31,6 @@ jobs:
 
           missing=()
           [[ -n "${{ secrets.CPLN_TOKEN_STAGING }}" ]] || missing+=("secret:CPLN_TOKEN_STAGING")
-          [[ -n "${{ secrets.SHARED_POSTGRES_URL_PREFIX }}" ]] || missing+=("secret:SHARED_POSTGRES_URL_PREFIX")
 
           if [[ ${#missing[@]} -gt 0 ]]; then
             printf 'Missing required GitHub configuration:\n- %s\n' "${missing[@]}" >&2
@@ -84,6 +83,7 @@ jobs:
       - name: Ensure shared Postgres identity and database secret
         env:
           SHARED_POSTGRES_URL_PREFIX: ${{ secrets.SHARED_POSTGRES_URL_PREFIX }}
+          SHARED_POSTGRES_SOURCE_SECRET: ${{ vars.SHARED_POSTGRES_SOURCE_SECRET || 'react-on-rails-hn-rsc-demo-staging-database' }}
         shell: bash
         run: script/control-plane/ensure-shared-postgres-secret
 

--- a/script/control-plane/ensure-shared-postgres-secret
+++ b/script/control-plane/ensure-shared-postgres-secret
@@ -3,12 +3,41 @@ set -euo pipefail
 
 : "${APP_NAME:?APP_NAME environment variable is required}"
 : "${CPLN_ORG:?CPLN_ORG environment variable is required}"
-: "${SHARED_POSTGRES_URL_PREFIX:?SHARED_POSTGRES_URL_PREFIX secret is required}"
 
-postgres_url_prefix="${SHARED_POSTGRES_URL_PREFIX%/}"
+postgres_url_prefix="${SHARED_POSTGRES_URL_PREFIX:-}"
+source_secret_name="${SHARED_POSTGRES_SOURCE_SECRET:-}"
 secret_name="${APP_NAME}-database"
 policy_name="${secret_name}-policy"
 review_app_prefix="${REVIEW_APP_PREFIX:-react-on-rails-hn-rsc-demo-review-pr}"
+
+if [[ -z "$postgres_url_prefix" ]]; then
+  if [[ -z "$source_secret_name" ]]; then
+    echo "Set SHARED_POSTGRES_URL_PREFIX or SHARED_POSTGRES_SOURCE_SECRET." >&2
+    exit 1
+  fi
+
+  postgres_url_prefix="$(
+    cpln secret reveal "$source_secret_name" --org "$CPLN_ORG" -o json |
+      ruby -rjson -ruri -e '
+        secret = JSON.parse(STDIN.read)
+        data = secret.fetch("data")
+        url = data.fetch("DATABASE_URL")
+        url = url.fetch("value") if url.is_a?(Hash) && url.key?("value")
+
+        begin
+          uri = URI(url)
+          uri.path = ""
+          uri.query = nil
+          uri.fragment = nil
+          print uri.to_s.sub(%r{/+\z}, "")
+        rescue URI::InvalidURIError
+          print url.sub(%r{/[^/?#]*(?:[?#].*)?\z}, "")
+        end
+      '
+  )"
+fi
+
+postgres_url_prefix="${postgres_url_prefix%/}"
 
 if [[ "${APP_NAME}" == "${review_app_prefix}"-* ]]; then
   default_runtime_secret_name="${review_app_prefix}-secrets"


### PR DESCRIPTION
## Summary
- allow staging/review deploys to derive the shared Postgres URL prefix from an existing Control Plane database secret
- keep SHARED_POSTGRES_URL_PREFIX supported, but no longer require storing the DB prefix in GitHub Actions secrets
- document SHARED_POSTGRES_SOURCE_SECRET fallback behavior

## Verification
- bash -n script/control-plane/ensure-shared-postgres-secret
- bin/test-cpflow-github-flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys now depend on Control Plane `secret reveal` and correct `DATABASE_URL` parsing; misconfigured source secrets or token permissions could break database setup for review/staging apps.
> 
> **Overview**
> Staging and review deploys no longer **require** `SHARED_POSTGRES_URL_PREFIX` in GitHub secrets when an existing Control Plane database dictionary secret is available.
> 
> `ensure-shared-postgres-secret` now accepts either the GitHub secret or `SHARED_POSTGRES_SOURCE_SECRET` (default `react-on-rails-hn-rsc-demo-staging-database`). If the prefix is missing, it **reveals** that secret, reads `DATABASE_URL`, and strips the database path to build the shared URL prefix before creating `<app-name>-database` as before. Review and staging workflows pass the new variable and only enforce `CPLN_TOKEN_STAGING` at validation time.
> 
> Docs in `.controlplane/readme.md` and `.github/cpflow-help.md` describe the optional secret/variable pairing and the default source secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8afbc2f29709bf51a498302594fbc6bc334775c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->